### PR TITLE
Fix problem with import for RSS

### DIFF
--- a/rss/categories_rss.py
+++ b/rss/categories_rss.py
@@ -10,7 +10,7 @@
     :copyright: Copyright 2013 by Atamert Ölçgen
     :license: BSD license
 '''
-import rss
+from rss import rss
 from tinkerer import utils
 
 

--- a/rss/tags_rss.py
+++ b/rss/tags_rss.py
@@ -10,7 +10,7 @@
     :copyright: Copyright 2013 by Atamert Ölçgen
     :license: BSD license
 '''
-import rss
+from rss import rss
 from tinkerer import utils
 
 


### PR DESCRIPTION
When try to use RSS extension with Python 3.4 get one error:

```
$ python --version
Python 3.4.0
$ tinker --version
Tinkerer version 1.2.1
$ tinker -b
....
Exception occurred:
  File "/path/to/_exts/rss/categories_rss.py", line 30, in generate_feeds
    for name, context, template in rss.generate_feed(app, category_name, posts):
AttributeError: 'module' object has no attribute 'generate_feed'
```

The fix for the problem come from
http://stackoverflow.com/a/11404052/1802726.
